### PR TITLE
Feature/settings

### DIFF
--- a/example_configs/Elmo.yaml
+++ b/example_configs/Elmo.yaml
@@ -18,9 +18,12 @@ Hardware:
   tx_pdo_type:                                    "TxPdoStandard"
   mode_of_operation:                              "CyclicSynchronousTorqueMode"
   use_multiple_modes_of_operation:                true
-  position_encoder_resolution:                    66
-  gear_ratio:                                     [1,1]
+  position_encoder_resolution:                    66 # Encoder 'ticks' per encoder revolution
+  gear_ratio:                                     [1,1] # [input revolutions, output revolutions]
   motor_constant:                                 1.0
   max_current:                                    5.0
   motor_rated_current:                            1.0
   direction:                                      1
+# direction :                                     -1
+  encoder_position:                               motor
+# encoder_position:                               joint

--- a/example_configs/Elmo.yaml
+++ b/example_configs/Elmo.yaml
@@ -23,3 +23,4 @@ Hardware:
   motor_constant:                                 1.0
   max_current:                                    5.0
   motor_rated_current:                            1.0
+  direction:                                      1

--- a/example_configs/Elmo.yaml
+++ b/example_configs/Elmo.yaml
@@ -27,3 +27,71 @@ Hardware:
 # direction :                                     -1
   encoder_position:                               motor
 # encoder_position:                               joint
+
+# Explanation for some **Hardware** parameters
+# ════════════════════════════════════════════
+
+# motor_rated_current:
+# ────────────────────
+
+#   This is used as an internal scaling factor. The hardware can set the
+#   target current to (signed) integer multiples of
+#   motor_rated_current/1000. The current gets represented as a 16bit
+#   signed integer. Setting motor_rated_current to an expected average
+#   current value is good practice. This value must be greater than 0.
+
+
+# gear_ratio:
+# ───────────
+
+#   Represents the gearing ratio between the motor and the joint as an
+#   array of two unsigned integers:
+
+#   [input revolutions, output revolutions].
+
+
+# direction:
+# ──────────
+
+#   Either 1 or -1, for positive and negative direction respectively. The
+#   ’positive’ direction is defined by the hardware configuration of the
+#   Elmo (EASII gui).
+
+
+# encoder_position:
+# ─────────────────
+
+#   Either ’motor’ or ’joint’.
+#   • ’motor’: The encoder is assumed to be on the motor side of the
+#     gearing. This means that ’position_encoder_resolution’ is assumed to
+#     be the number of ticks per MOTOR REVOLUTION. The velocity and
+#     position values read from the drive will thus be divided by the gear
+#     ratio, while the velocity commands will by multiplied by the gear
+#     ratio (where gear ratio = input_revolutions / output_revolutions).
+#   • ’joint’: The encoder is assumed to be on the joint side of the
+#     gearing. This means that ’position_encoder_resolution’ is assumed to
+#     be the number of ticks per JOINT REVOLUTION. The velocity and
+#     position values read from and commanded to the drive will thus not
+#     be altered.
+
+#   Note: All commands / readings are always in joint space (if the gear
+#   ratio is set correctly). A correct configuration of the Elmo drives
+#   over the EASII gui is required in order for the torque / current
+#   /velocity readings and commands to have the correct magnitude and
+#   sign.
+
+
+# use_multiple_modes_of_operation:
+# ────────────────────────────────
+
+#   Boolean value.
+#   • true: The mode of operation can be changed at any time during the
+#     PDO communication by calling
+#     ┌────
+#     │ elmo::Command::setModeOfOperation(elmo::ModeOfOperationEnum::...)
+#     └────
+#     The mode of operation is initialized by the mode from the config
+#     parameter ’mode_of_operation’. Whenever a command has the mode of
+#     operation ’NA’ (e.g. no mode has been set explicitly) then the mode
+#     is not changed, i.e. the old mode continues to be used. This
+#     requires that The standard rx and tx PDO types are used.

--- a/include/elmo_ethercat_sdk/Configuration.hpp
+++ b/include/elmo_ethercat_sdk/Configuration.hpp
@@ -30,8 +30,13 @@
 namespace elmo {
 
 class Configuration {
-
  public:
+  enum class EncoderPosition{
+    motor,
+    joint,
+    NA
+  };
+
   ModeOfOperationEnum modeOfOperationEnum{ModeOfOperationEnum::NA};
   RxPdoTypeEnum rxPdoTypeEnum{RxPdoTypeEnum::NA};
   TxPdoTypeEnum txPdoTypeEnum{TxPdoTypeEnum::NA};
@@ -51,7 +56,16 @@ class Configuration {
   double motorRatedCurrentA{0};
   double maxCurrentA{0};
   bool useMultipleModeOfOperations{false};
-  int direction{1};
+  int direction{0};
+  EncoderPosition encoderPosition{EncoderPosition::NA};
+
+  /*!
+   * @brief Check whether the parameters are sane.
+   * Prints a list of the checks and whether they failed or passed.
+   * @param[in] silent If true: Do not print. Only return the success of the test.
+   * @return true if the checks are successful.
+   */
+  bool sanityCheck(bool silent = false);
 
  public:
   // stream operator

--- a/include/elmo_ethercat_sdk/Configuration.hpp
+++ b/include/elmo_ethercat_sdk/Configuration.hpp
@@ -51,6 +51,7 @@ class Configuration {
   double motorRatedCurrentA{0};
   double maxCurrentA{0};
   bool useMultipleModeOfOperations{false};
+  int direction{1};
 
  public:
   // stream operator

--- a/src/elmo_ethercat_sdk/Configuration.cpp
+++ b/src/elmo_ethercat_sdk/Configuration.cpp
@@ -76,6 +76,14 @@ std::ostream& operator<<(std::ostream& os, const Configuration& configuration) {
   std::string rxPdo = rxPdoString(configuration.rxPdoTypeEnum);
   std::string txPdo = txPdoString(configuration.txPdoTypeEnum);
 
+  std::string direction_ = "";
+  if(configuration.direction == 1)
+    direction_ = "+1";
+  else if(configuration.direction == -1)
+    direction_ = "-1";
+  else
+    direction_ = "ERROR";
+
   // The size of the second columne
   unsigned int tmp1 = rxPdo.size();
   unsigned int tmp2 = txPdo.size();
@@ -92,6 +100,8 @@ std::ostream& operator<<(std::ostream& os, const Configuration& configuration) {
      << "|\n"
      << std::setfill(' ') << std::setw(43) << "| Mode of Operation:"
      << "| " << std::setw(len2) << modeOfOperation_ << "|\n"
+     << std::setfill(' ') << std::setw(43) << "| Direction:"
+     << "| " << std::setw(len2) << direction_ << "|\n"
      << std::setw(43) << "| Rx PDO Type:"
      << "| " << std::setw(len2) << rxPdo << "|\n"
      << std::setw(43) << "| Tx PDO Type:"

--- a/src/elmo_ethercat_sdk/ConfigurationParser.cpp
+++ b/src/elmo_ethercat_sdk/ConfigurationParser.cpp
@@ -294,6 +294,10 @@ void ConfigurationParser::parseConfiguration(YAML::Node configNode) {
     if (getValueFromFile(hardwareNode, "use_multiple_modes_of_operation", useMultipleModeOfOperations)) {
       configuration_.useMultipleModeOfOperations = useMultipleModeOfOperations ;
     }
+    int direction;
+    if (getValueFromFile(hardwareNode, "direction", direction)) {
+      configuration_.direction = direction;
+    }
   }
 }
 

--- a/src/elmo_ethercat_sdk/ConfigurationParser.cpp
+++ b/src/elmo_ethercat_sdk/ConfigurationParser.cpp
@@ -336,9 +336,6 @@ void ConfigurationParser::parseConfiguration(YAML::Node configNode) {
       configuration_.encoderPosition = encoderPosition;
     }
   }
-  if(!configuration_.sanityCheck(true)){
-    throw std::runtime_error("Parsed Configuration did not pass sanity check");
-  }
 }
 
 Configuration ConfigurationParser::getConfiguration() const {

--- a/src/elmo_ethercat_sdk/Elmo.cpp
+++ b/src/elmo_ethercat_sdk/Elmo.cpp
@@ -112,12 +112,12 @@ namespace elmo{
     switch (configuration_.rxPdoTypeEnum) {
       case RxPdoTypeEnum::RxPdoStandard: {
         RxPdoStandard rxPdo{};
-        rxPdo.targetPosition_ = stagedCommand_.getTargetPositionRaw();
-        rxPdo.targetVelocity_ = stagedCommand_.getTargetVelocityRaw();
-        rxPdo.targetTorque_ = stagedCommand_.getTargetTorqueRaw();
+        rxPdo.targetPosition_ = stagedCommand_.getTargetPositionRaw() * configuration_.direction;
+        rxPdo.targetVelocity_ = stagedCommand_.getTargetVelocityRaw() * configuration_.direction;
+        rxPdo.targetTorque_ = stagedCommand_.getTargetTorqueRaw() * configuration_.direction;
         rxPdo.maxTorque_ = stagedCommand_.getMaxTorqueRaw();
         rxPdo.modeOfOperation_ = static_cast<int8_t>(modeOfOperation_);
-        rxPdo.torqueOffset_ = stagedCommand_.getTorqueOffsetRaw();
+        rxPdo.torqueOffset_ = stagedCommand_.getTorqueOffsetRaw() * configuration_.direction;
         rxPdo.controlWord_ = controlword_.getRawControlword();
 
         // actually writing to the hardware
@@ -125,7 +125,7 @@ namespace elmo{
       } break;
       case RxPdoTypeEnum::RxPdoCST: {
         RxPdoCST rxPdo{};
-        rxPdo.targetTorque_ = stagedCommand_.getTargetTorqueRaw();
+        rxPdo.targetTorque_ = stagedCommand_.getTargetTorqueRaw() * configuration_.direction;
         rxPdo.modeOfOperation_ = static_cast<int8_t>(modeOfOperation_);
         rxPdo.controlWord_ = controlword_.getRawControlword();
 
@@ -150,23 +150,23 @@ namespace elmo{
         TxPdoStandard txPdo{};
         // reading from the bus
         bus_->readTxPdo(address_, txPdo);
-        reading_.setActualPosition(txPdo.actualPosition_);
+        reading_.setActualPosition(txPdo.actualPosition_ * configuration_.direction);
         reading_.setDigitalInputs(txPdo.digitalInputs_);
-        reading_.setActualVelocity(txPdo.actualVelocity_);
+        reading_.setActualVelocity(txPdo.actualVelocity_ * configuration_.direction);
         reading_.setStatusword(txPdo.statusword_);
         reading_.setAnalogInput(txPdo.analogInput_);
-        reading_.setActualCurrent(txPdo.actualCurrent_);
+        reading_.setActualCurrent(txPdo.actualCurrent_ * configuration_.direction);
         reading_.setBusVoltage(txPdo.busVoltage_);
       } break;
       case TxPdoTypeEnum::TxPdoCST: {
         TxPdoCST txPdo{};
         // reading from the bus
         bus_->readTxPdo(address_, txPdo);
-        reading_.setActualPosition(txPdo.actualPosition_);
-        reading_.setActualCurrent(txPdo.actualTorque_);  /// torque readings are actually current readings,
+        reading_.setActualPosition(txPdo.actualPosition_ * configuration_.direction);
+        reading_.setActualCurrent(txPdo.actualTorque_ * configuration_.direction);  /// torque readings are actually current readings,
                                                         /// the conversion is handled later
         reading_.setStatusword(txPdo.statusword_);
-        reading_.setActualVelocity(txPdo.actualVelocity_);
+        reading_.setActualVelocity(txPdo.actualVelocity_ * configuration_.direction);
       } break;
 
       default:

--- a/src/elmo_ethercat_sdk/Elmo.cpp
+++ b/src/elmo_ethercat_sdk/Elmo.cpp
@@ -220,7 +220,7 @@ namespace elmo{
 
     stagedCommand_.doUnitConversion();
 
-    if(allowModeChange_){
+    if(allowModeChange_ && command.getModeOfOperation() != ModeOfOperationEnum::NA){
       modeOfOperation_ = command.getModeOfOperation();
     }else{
       if(modeOfOperation_ != command.getModeOfOperation() && command.getModeOfOperation() != ModeOfOperationEnum::NA){

--- a/src/elmo_ethercat_sdk/Elmo.cpp
+++ b/src/elmo_ethercat_sdk/Elmo.cpp
@@ -262,7 +262,9 @@ namespace elmo{
 
   bool Elmo::loadConfigFile(const std::string &fileName){
     ConfigurationParser configurationParser(fileName);
-    return loadConfiguration(configurationParser.getConfiguration());
+    const bool success = loadConfiguration(configurationParser.getConfiguration());
+    if (!success) throw std::runtime_error("Parsed Configuration did not pass sanity check");
+    return success;
   }
 
   bool Elmo::loadConfigNode(YAML::Node configNode){

--- a/src/elmo_ethercat_sdk/Reading.cpp
+++ b/src/elmo_ethercat_sdk/Reading.cpp
@@ -263,9 +263,13 @@ void Reading::configureReading(const Configuration& configuration) {
   forceAppendEqualError_ = configuration.forceAppendEqualError;
   forceAppendEqualFault_ = configuration.forceAppendEqualFault;
 
-  positionFactorIntegerToRad_ = (2.0 * M_PI) / static_cast<double>(configuration.positionEncoderResolution);
-
-  velocityFactorIntegerPerSecToRadPerSec_ = (2.0 * M_PI) / static_cast<double>(configuration.positionEncoderResolution);
+  if(configuration.encoderPosition == Configuration::EncoderPosition::joint){
+    positionFactorIntegerToRad_ = (2.0 * M_PI) / static_cast<double>(configuration.positionEncoderResolution);
+    velocityFactorIntegerPerSecToRadPerSec_ = (2.0 * M_PI) / static_cast<double>(configuration.positionEncoderResolution);
+  } else if(configuration.encoderPosition == Configuration::EncoderPosition::motor){
+    positionFactorIntegerToRad_ = (2.0 * M_PI) / static_cast<double>(configuration.positionEncoderResolution) / configuration.gearRatio;
+    velocityFactorIntegerPerSecToRadPerSec_ = (2.0 * M_PI) / static_cast<double>(configuration.positionEncoderResolution) / configuration.gearRatio;
+  }
 
   double currentFactor = configuration.motorRatedCurrentA / 1000.0;
 


### PR DESCRIPTION
# New settings / better configuration
The following settings are _new_:

- direction: set motor direction
- encoder position: specify whether the encoder is on the joint or motor side of the gears.
- An explanation of some config parameters that are not completely self explanatory has been added.

The following other things have been changed / added:

- Sanity check for configuration object. Includes an intuitive printout in either green or red such that people actually use this feature (instead of only checking a return value which is often omitted in certain projects)
- A small fix for the mode of operations when 'use_multiple_modes_of_operation' is set to true.
- Better example config file