### PR TITLE
Feature/5 v value

### DIFF
--- a/include/elmo_ethercat_sdk/Elmo.hpp
+++ b/include/elmo_ethercat_sdk/Elmo.hpp
@@ -77,6 +77,9 @@ namespace elmo {
       bool setDriveStateViaPdo(const DriveState& driveState, const bool waitForState);
       bool lastPdoStateChangeSuccessful() const { return stateChangeSuccessful_; }
 
+    // Other
+      double getActual5vVoltage() { return actual5vVoltage_; }
+
     protected:
       void engagePdoStateMachine();
       bool mapPdos(RxPdoTypeEnum rxPdoTypeEnum, TxPdoTypeEnum txPdoTypeEnum);
@@ -106,6 +109,8 @@ namespace elmo {
       uint16_t numberOfSuccessfulTargetStateReadings_{0};
       std::atomic<bool> stateChangeSuccessful_{false};
 
+      // actual voltage on 5v line (e.g. to configure analog sensors)
+      double actual5vVoltage_{5.0};
 
     // Configurable parameters
     protected:

--- a/src/elmo_ethercat_sdk/Elmo.cpp
+++ b/src/elmo_ethercat_sdk/Elmo.cpp
@@ -96,6 +96,11 @@ namespace elmo{
     uint16_t maxCurrent = static_cast<uint16_t>(floor(1000.0 * configuration_.maxCurrentA));
     success &= sdoVerifyWrite(OD_INDEX_MAX_CURRENT, 0, false, maxCurrent);
 
+    // Actual voltage on 5v bus (e.g. for connected analog sensors)
+    uint16_t actual5vVoltage = 5000;
+    success &= sendSdoRead(OD_INDEX_5VDC_SUPPLY, 0, false, actual5vVoltage); // [mV]
+    actual5vVoltage_ = static_cast<double>(actual5vVoltage)/1000.0; // [V]
+
     if(!success){
       MELO_ERROR_STREAM("[elmo_ethercat_sdk:Elmo::preStartupOnlineConfiguration] hardware configuration of '"
                         << name_ <<"' not successful!");


### PR DESCRIPTION
# Elmo 5V Bus: Actual value
Reads the actual value of the Elmo's 5V line during startup.
This is useful to configure analog sensors powered by this voltage.

This is required for the MABI platform